### PR TITLE
Added support to allow overriding the location of AWS credentials file v...

### DIFF
--- a/lib/elastic/beanstalk/tasks/eb.rake
+++ b/lib/elastic/beanstalk/tasks/eb.rake
@@ -393,6 +393,10 @@ namespace :eb do
   end
 
   def aws_secrets_file
-    File.expand_path("~/.aws/#{EbConfig.app}.yml")
+    if ENV['ELASTIC_BEANSTALK_CREDENTIALS_DIR'].nil?
+      File.expand_path("~/.aws/#{EbConfig.app}.yml")
+    else
+      File.expand_path("#{ENV['ELASTIC_BEANSTALK_CREDENTIALS_DIR']}/#{EbConfig.app}.yml")
+    end    
   end
 end


### PR DESCRIPTION
Hi there,

This is a minor tweak to allow a user to override the location that the Rake tasks use to find the AWS credentials YAML file. Supporting an environment variable made sense. 

Please take a look and see what you think.

Thanks,
Nass
