### PR TITLE
Add support to configure different tiers

### DIFF
--- a/lib/elastic/beanstalk/tasks/eb.rake
+++ b/lib/elastic/beanstalk/tasks/eb.rake
@@ -324,7 +324,8 @@ namespace :eb do
     options[:package_bucket] = EbConfig.package_bucket unless EbConfig.package_bucket.nil?
     options[:keep_latest] = EbConfig.keep_latest unless EbConfig.keep_latest.nil?
     options[:version_prefix] = EbConfig.version_prefix unless EbConfig.version_prefix.nil?
-
+    options[:tier] = EbConfig.tier unless EbConfig.tier.nil?
+    
     unless EbConfig.smoke_test.nil?
       options[:smoke_test] = eval EbConfig.smoke_test
     end


### PR DESCRIPTION
`eb_deployer` supports deploying workers and web servers, but `elastic-beanstalk` does not.
However, the use case does not go away. This PR adds support to add the tier option to pass along to `eb_deployer`.

`tier` is an optional argument, and defaults to `nil`, so this change backwards compatible.