### PR TITLE
Update README.md example config inactive settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,10 @@ options:
 inactive:
   aws:autoscaling:asg:
     MinSize: 0
-    Cooldown: 900    
+    MaxSize: 0
+    Cooldown: 900
+  aws:autoscaling:updatepolicy:rollingupdate:
+    RollingUpdateEnabled: false    
 
 #---
 development:


### PR DESCRIPTION
Ensure rolling updates are disabled on inactive auto scaling group during blue green deployments to avoid configuration errors