### PR TITLE
Allow eb.yml to specify the RAILS_ENV and RACK_ENV

### DIFF
--- a/lib/elastic/beanstalk/tasks/eb.rake
+++ b/lib/elastic/beanstalk/tasks/eb.rake
@@ -160,9 +160,13 @@ namespace :eb do
     end
     EbConfig.load!(environment, filename)
 
-    # Let's be explicit regardless of 'production' being the eb's default shall we? Set RACK_ENV and RAILS_ENV based on the given environment
-    EbConfig.set_option(:'aws:elasticbeanstalk:application:environment', 'RACK_ENV', "#{EbConfig.environment}")
-    EbConfig.set_option(:'aws:elasticbeanstalk:application:environment', 'RAILS_ENV', "#{EbConfig.environment}")
+    # Set RACK_ENV and RAILS_ENV based on the given environment or the provided configuration
+    unless EbConfig.configuration.dig(:options, :'aws:elasticbeanstalk:application:environment', :RACK_ENV)
+      EbConfig.set_option(:'aws:elasticbeanstalk:application:environment', 'RACK_ENV', "#{EbConfig.environment}")
+    end
+    unless EbConfig.configuration.dig(:options, :'aws:elasticbeanstalk:application:environment', :RAILS_ENV)
+      EbConfig.set_option(:'aws:elasticbeanstalk:application:environment', 'RAILS_ENV', "#{EbConfig.environment}")
+    end
 
     #-------------------------------------------------------------------------------
     # resolve the version and set the APP_VERSION environment variable

--- a/spec/lib/elastic/beanstalk/eb_spec.yml
+++ b/spec/lib/elastic/beanstalk/eb_spec.yml
@@ -40,6 +40,7 @@ ebextensions:
 options:
   aws:elasticbeanstalk:application:environment:
     RAILS_ENV: foobar
+    RACK_ENV: bizbaz
 
   aws:autoscaling:launchconfiguration:
     InstanceType: foo

--- a/spec/lib/elastic/beanstalk/tasks/eb_rake_spec.rb
+++ b/spec/lib/elastic/beanstalk/tasks/eb_rake_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+require 'rake'
+
+# The `credentials` method is called against the main ruby object.
+# We maintain a reference to it so that we can avoid setting real credentials in the test.
+# This test reaches in to set the @credentials ivar instead of stubbing a method because
+# reliably stubbing and unstubbing a global object is error prone and would affect other tests.
+$main = self
+
+describe 'eb namespace rake task' do
+  describe 'eb:config' do
+    before do
+      load 'lib/elastic/beanstalk/tasks/eb.rake'
+      Rake::Task.define_task(:environment)
+      $main.instance_variable_set(:@credentials, {})
+      allow(EbConfig).to receive(:resolve_path).and_return('spec/lib/elastic/beanstalk/eb_spec.yml')
+      # We could run eb:show_config, but it is easier to access the data directly
+      Rake::Task['eb:config'].invoke('staging')
+    end
+
+    after do
+      $main.remove_instance_variable(:@credentials)
+    end
+
+    it 'should not override the RAILS_ENV in eb.yml' do
+      rails_env = EbConfig.configuration.dig(:options,
+                                             :'aws:elasticbeanstalk:application:environment',
+                                             :RAILS_ENV)
+      expect(rails_env).to eq('foobar')
+    end
+
+    it 'should not override the RACK_ENV in eb.yml' do
+      rack_env = EbConfig.configuration.dig(:options,
+                                             :'aws:elasticbeanstalk:application:environment',
+                                             :RACK_ENV)
+      expect(rack_env).to eq('bizbaz')
+    end
+  end
+end


### PR DESCRIPTION
This changes the eb:config task to skip over setting these ENV variables
if they are set by the config file. This allows eb environments to use
rails environments which do not map directly to the name of the eb
environment.

closes #41