### PR TITLE
Remove ruby 2.3-only Hash#dig reference and used chained fetch

### DIFF
--- a/lib/elastic/beanstalk/tasks/eb.rake
+++ b/lib/elastic/beanstalk/tasks/eb.rake
@@ -161,10 +161,14 @@ namespace :eb do
     EbConfig.load!(environment, filename)
 
     # Set RACK_ENV and RAILS_ENV based on the given environment or the provided configuration
-    unless EbConfig.configuration.dig(:options, :'aws:elasticbeanstalk:application:environment', :RACK_ENV)
+    unless EbConfig.configuration.fetch(:options, {})
+                                 .fetch(:'aws:elasticbeanstalk:application:environment',{})
+                                 .fetch(:RACK_ENV, nil)
       EbConfig.set_option(:'aws:elasticbeanstalk:application:environment', 'RACK_ENV', "#{EbConfig.environment}")
     end
-    unless EbConfig.configuration.dig(:options, :'aws:elasticbeanstalk:application:environment', :RAILS_ENV)
+    unless EbConfig.configuration.fetch(:options, {})
+                                 .fetch(:'aws:elasticbeanstalk:application:environment',{})
+                                 .fetch(:RAILS_ENV, nil)
       EbConfig.set_option(:'aws:elasticbeanstalk:application:environment', 'RAILS_ENV', "#{EbConfig.environment}")
     end
 

--- a/spec/lib/elastic/beanstalk/tasks/eb_rake_spec.rb
+++ b/spec/lib/elastic/beanstalk/tasks/eb_rake_spec.rb
@@ -23,16 +23,16 @@ describe 'eb namespace rake task' do
     end
 
     it 'should not override the RAILS_ENV in eb.yml' do
-      rails_env = EbConfig.configuration.dig(:options,
-                                             :'aws:elasticbeanstalk:application:environment',
-                                             :RAILS_ENV)
+      rails_env = EbConfig.configuration.fetch(:options, {})
+                                        .fetch(:'aws:elasticbeanstalk:application:environment', {})
+                                        .fetch(:RAILS_ENV, nil)
       expect(rails_env).to eq('foobar')
     end
 
     it 'should not override the RACK_ENV in eb.yml' do
-      rack_env = EbConfig.configuration.dig(:options,
-                                             :'aws:elasticbeanstalk:application:environment',
-                                             :RACK_ENV)
+      rack_env = EbConfig.configuration.fetch(:options, {})
+                                       .fetch(:'aws:elasticbeanstalk:application:environment', {})
+                                       .fetch(:RACK_ENV, nil)
       expect(rack_env).to eq('bizbaz')
     end
   end


### PR DESCRIPTION
This fixes #41 where dig is undefined on Hash in ruby 2.2.2
