### PR TITLE
Allow passing tags options to eb_deployer.

### DIFF
--- a/lib/elastic/beanstalk/tasks/eb.rake
+++ b/lib/elastic/beanstalk/tasks/eb.rake
@@ -327,7 +327,8 @@ namespace :eb do
         option_settings: EbConfig.option_settings,
         inactive_settings: EbConfig.inactive_settings,
         strategy: EbConfig.strategy.to_sym,
-        package: package
+        package: package,
+        tags: EbConfig.tags
     }
 
     options[:package_bucket] = EbConfig.package_bucket unless EbConfig.package_bucket.nil?


### PR DESCRIPTION
Support passing the tags options to eb_deployer. It allows tagging the resources created so that a resource group can be created in AWS to manage all the resource associated to a tag. Note that it work only on creation due to eb_deployer limitation. Shoul fix issue #38.
